### PR TITLE
Fix non-military hour at 12 PM

### DIFF
--- a/simple-clock-card.js
+++ b/simple-clock-card.js
@@ -35,7 +35,7 @@ class SimpleClockCard extends HTMLElement {
 				let  use_military = config.use_military !== undefined ? config.use_military : true;
 				let  hide_seconds = config.hide_seconds !== undefined ? config.hide_seconds : false;
 
-				let time_str =  (use_military ? h : h % 12 ) +
+				let time_str =  (use_military ? h : ((h + 11) % 12) + 1 ) +
                    ":" +
                    m +
                    (hide_seconds ? "" : ":" + s ) +


### PR DESCRIPTION
Hereby proposing a change to fix a non-military time at 12th hour. Instead of 0, this change should show 12.

Tested on my local setup and it works fine.

This should fix the issue: https://github.com/fufar/simple-clock-card/issues/12
